### PR TITLE
Fix POD syntax warnings.

### DIFF
--- a/lib/IO/Event.pod
+++ b/lib/IO/Event.pod
@@ -217,7 +217,7 @@ input can be retrieved via directly reading it from
 C<$$input_buffer_reference> or via C<read()> from the
 $ioe filehandle, or by using a variety of standard
 methods for getting data: 
-	
+
 	<$ioe>			like IO::Handle
 	$ioe->get()		like Data::LineBuffer
 	$ioe->read()		like IO::Handle

--- a/lib/IO/Event/Callback.pm
+++ b/lib/IO/Event/Callback.pm
@@ -109,7 +109,7 @@ __END__
 
 =head1 NAME
 
- IO::Event::Callback - A closure based API for IO::Event
+IO::Event::Callback - A closure based API for IO::Event
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Minimal change to fix syntax warnings in the POD.

NB: There is a lot of trailing whitespace in the POD, that could do with
a tidy, but has not been removed as part of this changeset, as I want to
make a minimal commit.
